### PR TITLE
Standardized tsdoc usage

### DIFF
--- a/src/algorithms/Determinant.ts
+++ b/src/algorithms/Determinant.ts
@@ -5,8 +5,8 @@ import { assertSquare } from '../utilities/ErrorAssertions';
  * Uses expansion of minors to calculate the determinant of a matrix.
  * Throws an error if the input is not square.
  *
- * @param {Matrix<number>} matrix  a square matrix
- * @returns {number}  the determinant
+ * @param matrix - A square matrix
+ * @returns - The determinant
  */
 export function determinant<ScalarType>(matrix: Matrix<ScalarType>): ScalarType {
   assertSquare(matrix);

--- a/src/algorithms/FiniteDifferences.ts
+++ b/src/algorithms/FiniteDifferences.ts
@@ -10,10 +10,10 @@ import { VectorIndexFunction } from '../types/vector/VectorBuilder';
  * linspace(0, 1, 5); // [ 0, 0.2, 0.4, 0.6, 0.8 ]
  * ```
  *
- * @param {number} xMin  The smallest value in the vector
- * @param {number} xMax  The largest value in the vector
- * @param {number} binCount  The number of entries
- * @returns {Vector<number>}
+ * @param xMin - The smallest value in the vector
+ * @param xMax - The largest value in the vector
+ * @param binCount - The number of entries
+ * @returns The evenly-spaced vector
  */
 export function linspace(xMin: number, xMax: number, binCount: number): NumberVector {
   if (xMin >= xMax) {
@@ -45,8 +45,8 @@ export function linspace(xMin: number, xMax: number, binCount: number): NumberVe
  * // [  0  0 -1  1 ]
  * // [  0  0  0 -1 ]
  * ```
- * @param {number} binCount  The size of the vector to which the output ought to be applied
- * @returns {Matrix<number>}
+ * @param binCount - The size of the vector to which the output ought to be applied
+ * @returns The forward difference matrix
  */
 export function forwardDifferenceMatrix(binCount: number): NumberMatrix {
   return NumberMatrix.builder().tridiagonal(
@@ -72,8 +72,8 @@ export function forwardDifferenceMatrix(binCount: number): NumberMatrix {
  * // [  0 -1  1  0 ]
  * // [  0  0 -1  1 ]
  * ```
- * @param {number} binCount  The size of the vector to which the output ought to be applied
- * @returns {Matrix<number>}
+ * @param binCount - The size of the vector to which the output ought to be applied
+ * @returns The backward difference matrix
  */
 export function backwardDifferenceMatrix(binCount: number): NumberMatrix {
   return NumberMatrix.builder().tridiagonal(
@@ -101,8 +101,8 @@ export function backwardDifferenceMatrix(binCount: number): NumberMatrix {
  * // [   0  -1/2   0   1/2 ]
  * // [   0    0  -1/2   0  ]
  * ```
- * @param {number} binCount  The size of the vector to which the output ought to be applied
- * @returns {Matrix<number>}
+ * @param binCount - The size of the vector to which the output ought to be applied
+ * @returns The central difference matrix
  */
 export function centralDifferenceMatrix(binCount: number): NumberMatrix {
   return NumberMatrix.builder().tridiagonal(
@@ -124,11 +124,11 @@ export function centralDifferenceMatrix(binCount: number): NumberMatrix {
  * derivative(Math.sin, 0, 2*Math.PI, 100);
  * ```
  *
- * @param {(x: number) => number} f  A deterministic function with no side effects
- * @param {number} xMin  The minimum value for which the derivative will be approximated
- * @param {number} xMax  The maximum (exclusive) value for which the derivative will be approximated
- * @param {number} binCount  The number of approximations
- * @returns {Vector<number>}
+ * @param f - A deterministic function with no side effects
+ * @param xMin - The minimum value for which the derivative will be approximated
+ * @param xMax - The maximum (exclusive) value for which the derivative will be approximated
+ * @param binCount - The number of approximations
+ * @returns A linearly spaced vector whose values represent the values of the derivative
  */
 export function derivative(f: (x: number) => number, xMin: number, xMax: number, binCount: number) {
   const x = linspace(xMin, xMax, binCount);

--- a/src/algorithms/GaussJordan.ts
+++ b/src/algorithms/GaussJordan.ts
@@ -8,8 +8,8 @@ import { VectorData } from '../types/vector/Vector';
  * Throws an error if the matrix is not square.
  * Returns `undefined` if the matrix is not invertible.
  *
- * @param {Matrix<number>} matrix  A square matrix
- * @returns {Matrix<number> | undefined}
+ * @param matrix - A square matrix
+ * @returns The inverse matrix
  */
 export function inverse<ScalarType>(matrix: Matrix<ScalarType>): Matrix<ScalarType> | undefined {
   assertSquare(matrix);
@@ -33,8 +33,8 @@ export function inverse<ScalarType>(matrix: Matrix<ScalarType>): Matrix<ScalarTy
 /**
  * Uses Gauss-Jordan elimination to convert a matrix to Reduced Row-Echelon Form (RREF)
  *
- * @param {Matrix<ScalarType>} matrix
- * @returns {Matrix<ScalarType>}
+ * @param matrix - The input matrix
+ * @returns The matrix in RREF
  */
 export function reducedRowEchelonForm<ScalarType>(matrix: Matrix<ScalarType>): Matrix<ScalarType> {
   matrix = rowEchelonForm(matrix);
@@ -57,8 +57,8 @@ export function reducedRowEchelonForm<ScalarType>(matrix: Matrix<ScalarType>): M
 /**
  * Uses Gauss-Jordan elimination to convert a matrix to Row-Echelon Form (REF)
  *
- * @param {Matrix<ScalarType>} matrix
- * @returns {Matrix<ScalarType>}
+ * @param matrix - The input matrix
+ * @returns The matrix in REF
  */
 export function rowEchelonForm<ScalarType>(matrix: Matrix<ScalarType>): Matrix<ScalarType> {
   matrix = moveLeadingZerosToBottom(matrix);

--- a/src/algorithms/LeastSquares.ts
+++ b/src/algorithms/LeastSquares.ts
@@ -41,10 +41,10 @@ export type ApproximationFunctionTemplate<ScalarType> = (
  * - `approximationFunction`: a function which takes a vector of the independent variable
  *     values, and returns the predicted value of the dependent variable
  *
- * @param {Vector<ScalarType>[]} dataPoints - an array of vectors, each of which
+ * @param dataPoints - An array of vectors, each of which
  *    represents a single data point where the last entry is the variable to be predicted,
  *    and the other entries are the values of the independent variables
- * @returns {LeastSquaresApproximation<ScalarType>} - the result of the linear regression
+ * @returns - the result of the linear regression
  */
 export function calculateLinearLeastSquaresApproximation<ScalarType>(
   dataPoints: Vector<ScalarType>[]
@@ -82,13 +82,13 @@ export function calculateLinearLeastSquaresApproximation<ScalarType>(
  * - `approximationFunction`: a function which takes a vector of the independent variable
  *     values, and returns the predicted value of the dependent variable
  *
- * @param {Vector<ScalarType>} dataPoints - the data used to construct the approximation
- * @param {ApproximationFunctionTemplate<ScalarType>} functionTemplate - a higher-order
+ * @param dataPoints - The data used to construct the approximation
+ * @param functionTemplate - A higher-order
  *     function which takes a vector of coefficients and yields a new function which takes
  *     a vector of independent variables to produce a value for the dependent variable
- * @param {number} numberOfTerms - the number of coefficients needed to produce
+ * @param numberOfTerms - The number of coefficients needed to produce
  *     the approximation function
- * @returns {LeastSquaresApproximation<ScalarType>} - the result of the linear regression
+ * @returns - the result of the linear regression
  */
 export function calculateGeneralLeastSquaresApproximation<ScalarType>(
   dataPoints: Vector<ScalarType>[],
@@ -142,8 +142,8 @@ export function calculateGeneralLeastSquaresApproximation<ScalarType>(
  * This function returns the approximate solution _x_, or `undefined`
  * if _x_ does not exist
  *
- * @param {Matrix<ScalarType>} A - the matrix _A_ in _Ax = b_
- * @param {Vector<ScalarType>} b - the vector _b_ in _Ax = b_
+ * @param A - The matrix _A_ in _Ax = b_
+ * @param b - The vector _b_ in _Ax = b_
  */
 export function solveOverdeterminedSystem<ScalarType>(
   A: Matrix<ScalarType>,

--- a/src/algorithms/QRDecomposition.ts
+++ b/src/algorithms/QRDecomposition.ts
@@ -15,7 +15,7 @@ export type QRDecomposition<ScalarType> = {
  * That is, a unitary matrix Q and upper-triangular matrix R such that Q
  * multiplied by R yields A
  *
- * @param {Matrix<ScalarType>} A - the matrix to decompose
+ * @param A - The matrix to decompose
  */
 export function calculateQRDecomposition<ScalarType>(
   A: Matrix<ScalarType>

--- a/src/algorithms/RowOperations.ts
+++ b/src/algorithms/RowOperations.ts
@@ -5,10 +5,10 @@ export class RowOperations {
   /**
    * Returns a new matrix whose row at `rowIndex` is multipled by `scalar`
    *
-   * @param {Matrix<ScalarType>} matrix  The original matrix
-   * @param {number} rowIndex  The index of the row to modify
-   * @param {ScalarType} scalar  The factor by which to scale the row
-   * @returns {Matrix<number>}
+   * @param matrix - The original matrix
+   * @param rowIndex - The index of the row to modify
+   * @param scalar - The factor by which to scale the row
+   * @returns The matrix with the transformation applied
    */
   static multiplyRowByScalar<ScalarType>(
     matrix: Matrix<ScalarType>,
@@ -28,10 +28,10 @@ export class RowOperations {
   /**
    * Returns a new matrix whose row at `targetRow` has had the row at `rowToAdd` added to it.
    *
-   * @param {Matrix<ScalarType>} matrix  The original matrix
-   * @param {number} targetRow  The index of the row to modify
-   * @param {number} rowToAdd  The index of the row to add
-   * @returns {Matrix<ScalarType>}
+   * @param matrix - The original matrix
+   * @param targetRow - The index of the row to modify
+   * @param rowToAdd - The index of the row to add
+   * @returns The matrix with the transformation applied
    */
   static addRowToRow<ScalarType>(
     matrix: Matrix<ScalarType>,
@@ -49,11 +49,11 @@ export class RowOperations {
   /**
    * Returns a new matrix whose row at `targetRow` has had a scalar multiple of `rowToAdd` added to it.
    *
-   * @param {Matrix<ScalarType>} matrix  The original matrix
-   * @param {number} targetRow  The index of the row to modify
-   * @param {number} rowToAdd  The index of the row to be scaled and added
-   * @param {ScalarType} scalar  The factor by which to scale the row
-   * @returns {Matrix<ScalarType>}
+   * @param matrix - The original matrix
+   * @param targetRow - The index of the row to modify
+   * @param rowToAdd - The index of the row to be scaled and added
+   * @param scalar - The factor by which to scale the row
+   * @returns The matrix with the transformation applied
    */
   static addScalarMultipleOfRowToRow<ScalarType>(
     matrix: Matrix<ScalarType>,
@@ -76,10 +76,10 @@ export class RowOperations {
   /**
    * Returns a new matrix whose row at index `first` has been exchanged with the row at index `second`
    *
-   * @param {Matrix<ScalarType>} matrix  The original matrix
-   * @param {number} first  The index of the first row to exchange
-   * @param {number} second  The index of the second row to exchange
-   * @returns {Matrix<ScalarType>}
+   * @param matrix - The original matrix
+   * @param first - The index of the first row to exchange
+   * @param second - The index of the second row to exchange
+   * @returns The matrix with the transformation applied
    */
   static exchangeRows<ScalarType>(
     matrix: Matrix<ScalarType>,

--- a/src/types/matrix/ArrayMatrix.ts
+++ b/src/types/matrix/ArrayMatrix.ts
@@ -24,12 +24,18 @@ export abstract class ArrayMatrix<ScalarType> implements Matrix<ScalarType> {
   abstract builder(): MatrixBuilder<ScalarType, Vector<ScalarType>, Matrix<ScalarType>>;
   abstract vectorBuilder(): VectorBuilder<ScalarType, Vector<ScalarType>>;
 
+  /**
+   * @inheritdoc
+   */
   add(other: Matrix<ScalarType>): Matrix<ScalarType> {
     return this.builder().fromColumnVectors(
       this.getColumnVectors().map((column, columnIndex) => column.add(other.getColumn(columnIndex)))
     );
   }
 
+  /**
+   * @inheritdoc
+   */
   adjoint(): Matrix<ScalarType> {
     const transposedData = this.transpose().getData();
     const adjointData: MatrixData<ScalarType> = [];
@@ -42,11 +48,17 @@ export abstract class ArrayMatrix<ScalarType> implements Matrix<ScalarType> {
     return this.builder().fromData(adjointData);
   }
 
+  /**
+   * @inheritdoc
+   */
   apply(vector: Vector<ScalarType>): Vector<ScalarType> {
     const vectorAsColumnMatrix = this.builder().fromColumnVectors([vector]);
     return this.multiply(vectorAsColumnMatrix).getColumn(0);
   }
 
+  /**
+   * @inheritdoc
+   */
   equals(other: Matrix<ScalarType>): boolean {
     if (this.getNumberOfColumns() !== other.getNumberOfColumns()) {
       return false;
@@ -61,6 +73,9 @@ export abstract class ArrayMatrix<ScalarType> implements Matrix<ScalarType> {
       .reduce((all, current) => all && current, true);
   }
 
+  /**
+   * @inheritdoc
+   */
   getColumn(columnIndex: number): Vector<ScalarType> {
     if (columnIndex > this.getNumberOfColumns() - 1 || columnIndex < 0) {
       throw new Error('Index out of bounds');
@@ -68,27 +83,45 @@ export abstract class ArrayMatrix<ScalarType> implements Matrix<ScalarType> {
     return this.getColumnVectors()[columnIndex];
   }
 
+  /**
+   * @inheritdoc
+   */
   getColumnVectors(): Array<Vector<ScalarType>> {
     return this.transpose().getRowVectors();
   }
 
+  /**
+   * @inheritdoc
+   */
   getData(): MatrixData<ScalarType> {
     return this.getRowVectors().map(row => row.getData());
   }
 
+  /**
+   * @inheritdoc
+   */
   getEntry(rowIndex: number, columnIndex: number): ScalarType {
     assertValidMatrixIndex(this, rowIndex, columnIndex);
     return this.getRow(rowIndex).getEntry(columnIndex);
   }
 
+  /**
+   * @inheritdoc
+   */
   getNumberOfColumns(): number {
     return this.getColumnVectors().length;
   }
 
+  /**
+   * @inheritdoc
+   */
   getNumberOfRows(): number {
     return this.getRowVectors().length;
   }
 
+  /**
+   * @inheritdoc
+   */
   getRow(rowIndex: number): Vector<ScalarType> {
     if (rowIndex > this.getNumberOfRows() - 1 || rowIndex < 0) {
       throw new Error('Index out of bounds');
@@ -96,12 +129,18 @@ export abstract class ArrayMatrix<ScalarType> implements Matrix<ScalarType> {
     return this.getRowVectors()[rowIndex];
   }
 
+  /**
+   * @inheritdoc
+   */
   getRowVectors(): Array<Vector<ScalarType>> {
     return this._data.map((dataRow: VectorData<ScalarType>) =>
       this.vectorBuilder().fromData(dataRow)
     );
   }
 
+  /**
+   * @inheritdoc
+   */
   multiply(other: Matrix<ScalarType>): Matrix<ScalarType> {
     if (this.getNumberOfColumns() !== other.getNumberOfRows()) {
       throw new Error('Dimension mismatch');
@@ -114,22 +153,34 @@ export abstract class ArrayMatrix<ScalarType> implements Matrix<ScalarType> {
     );
   }
 
+  /**
+   * @inheritdoc
+   */
   scalarMultiply(scalar: ScalarType): Matrix<ScalarType> {
     return this.builder().fromColumnVectors(
       this.getColumnVectors().map(column => column.scalarMultiply(scalar))
     );
   }
 
+  /**
+   * @inheritdoc
+   */
   set(rowIndex: number, columnIndex: number, value: ScalarType): Matrix<ScalarType> {
     const copy = this.getData();
     copy[rowIndex][columnIndex] = value;
     return this.builder().fromData(copy);
   }
 
+  /**
+   * @inheritdoc
+   */
   transpose(): Matrix<ScalarType> {
     return this.builder().fromColumnVectors(this.getRowVectors());
   }
 
+  /**
+   * @inheritdoc
+   */
   forEachEntry(cb: MatrixEntryCallback<ScalarType>) {
     this.getRowVectors().forEach((row, i) => {
       row.getData().forEach((entry, j) => {

--- a/src/types/matrix/ComplexMatrix.ts
+++ b/src/types/matrix/ComplexMatrix.ts
@@ -24,14 +24,23 @@ export class ComplexMatrix extends ArrayMatrix<ComplexNumber> {
     return new VectorBuilder(ComplexVector);
   }
 
+  /**
+   * @inheritdoc
+   */
   ops() {
     return ComplexMatrix.ops();
   }
 
+  /**
+   * @inheritdoc
+   */
   builder(): MatrixBuilder<ComplexNumber, ComplexVector, ComplexMatrix> {
     return ComplexMatrix.builder();
   }
 
+  /**
+   * @inheritdoc
+   */
   vectorBuilder(): VectorBuilder<ComplexNumber, ComplexVector> {
     return ComplexMatrix.vectorBuilder();
   }

--- a/src/types/matrix/LinearTransformation.ts
+++ b/src/types/matrix/LinearTransformation.ts
@@ -11,8 +11,8 @@
 export interface LinearTransformation<V, U> {
   /**
    * Apply the linear transformation to a vector
-   * @param {V} vector  A vector in the domain of the transformation
-   * @returns {U}  A vector in the image of the transformation
+   * @param vector - A vector in the domain of the transformation
+   * @returns A vector in the image of the transformation
    */
   apply(vector: V): U;
 }

--- a/src/types/matrix/Matrix.ts
+++ b/src/types/matrix/Matrix.ts
@@ -24,51 +24,63 @@ export interface MatrixConstructor<
 
 export interface Matrix<ScalarType>
   extends LinearTransformation<Vector<ScalarType>, Vector<ScalarType>> {
+  /**
+   * Yields a `ScalarOperations` object which will allow consumers to work generically
+   * with the scalars contained in the vector.
+   */
   ops(): ScalarOperations<ScalarType>;
+
+  /**
+   * Yields a `MatrixBuilder` which will build new matrices of the same type
+   */
   builder(): MatrixBuilder<ScalarType, Vector<ScalarType>, Matrix<ScalarType>>;
+
+  /**
+   * Yields a `VectorBuilder` which will build new vectors of a compatible type
+   */
   vectorBuilder(): VectorBuilder<ScalarType, Vector<ScalarType>>;
 
   /**
-   * @returns {MatrixData<ScalarType>}  The contents of the matrix as an array of arrays.
+   * @returns The contents of the matrix as an array of arrays.
    */
   getData(): MatrixData<ScalarType>;
 
   /**
-   * @returns {number}  The number of rows in the matrix
+   * @returns The number of rows in the matrix
    */
   getNumberOfRows(): number;
 
   /**
-   * @returns {number}  The number of columns in the matrix
+   * @returns The number of columns in the matrix
    */
   getNumberOfColumns(): number;
 
   /**
-   * @returns {Array<Vector<ScalarType>>} An array of vectors corresponding to the rows of the matrix
+   * @returns An array of vectors corresponding to the rows of the matrix
    */
   getRowVectors(): Array<Vector<ScalarType>>;
 
   /**
-   * @param {number} rowIndex  The index for which to fetch the row
-   * @returns {Vector<ScalarType>}  A vector corresponding to the row at index `rowIndex`
+   * @param rowIndex - The index for which to fetch the row
+   * @returns A vector corresponding to the row at index `rowIndex`
    */
   getRow(rowIndex: number): Vector<ScalarType>;
 
   /**
-   * @returns {Array<Vector<ScalarType>>}  An array of vectors corresponding to the columns of the matrix
+   * @returns An array of vectors corresponding to the columns of the matrix
    */
   getColumnVectors(): Array<Vector<ScalarType>>;
 
   /**
-   * @param {number} columnIndex  The index for which to fetch the column
-   * @returns {Vector<ScalarType>}  A vector corresponding to the column at index `columnIndex`
+   * @param columnIndex - The index for which to fetch the column
+   * @returns A vector corresponding to the column at index `columnIndex`
    */
   getColumn(columnIndex: number): Vector<ScalarType>;
 
   /**
-   * @param {number} rowIndex  The index of the row containing the entry
-   * @param {number} columnIndex  The index of the column containing the entry
-   * @returns {ScalarType}  The entry located at `(rowIndex, columnIndex)`
+   * @param rowIndex - The index of the row containing the entry
+   * @param columnIndex - The index of the column containing the entry
+   * @returns The entry located at `(rowIndex, columnIndex)`
    */
   getEntry(rowIndex: number, columnIndex: number): ScalarType;
 
@@ -76,53 +88,53 @@ export interface Matrix<ScalarType>
    * Returns a *new* matrix equal to the old one, except with the entry at
    * `(rowIndex, columnIndex)` replaced with `value`
    *
-   * @param {number} rowIndex  The row containing the value to replace
-   * @param {number} columnIndex  The column containing the value to replace
-   * @param {ScalarType} value  The new value
-   * @returns {Matrix<ScalarType>}  A new matrix
+   * @param rowIndex - The row containing the value to replace
+   * @param columnIndex - The column containing the value to replace
+   * @param value - The new value
+   * @returns A new matrix
    */
   set(rowIndex: number, columnIndex: number, value: ScalarType): Matrix<ScalarType>;
 
   /**
    * Implements matrix multiplication
-   * @param {Matrix<ScalarType>} other  The matrix by which to multiply
-   * @returns {Matrix<ScalarType>}  The matrix product
+   * @param other - The matrix by which to multiply
+   * @returns The matrix product
    */
   multiply(other: Matrix<ScalarType>): Matrix<ScalarType>;
 
   /**
-   * @returns {Matrix<ScalarType>}  The adjoint of the matrix
+   * @returns The adjoint of the matrix
    */
   adjoint(): Matrix<ScalarType>;
 
   /**
-   * @returns {Matrix<ScalarType>}  The transpose of the matrix
+   * @returns The transpose of the matrix
    */
   transpose(): Matrix<ScalarType>;
 
   /**
    * Implements matrix addition
-   * @param {Matrix<ScalarType>} other  The matrix to add
-   * @returns {Matrix<ScalarType>}  The matrix sum
+   * @param other - The matrix to add
+   * @returns The matrix sum
    */
   add(other: Matrix<ScalarType>): Matrix<ScalarType>;
 
   /**
    * Implements multiplication of a matrix by a scalar
-   * @param {ScalarType} scalar  The scalar by which to multiply
-   * @returns {Matrix<ScalarType>}  The product
+   * @param scalar - The scalar by which to multiply
+   * @returns The product
    */
   scalarMultiply(scalar: ScalarType): Matrix<ScalarType>;
 
   /**
-   * @param {Matrix<ScalarType>} other
-   * @returns {boolean}  true if `this` is equal to `other`
+   * @param other - The matrix against which to compare
+   * @returns true if `this` is equal to `other`
    */
   equals(other: Matrix<ScalarType>): boolean;
 
   /**
    * Executes the `callback` function for each entry in the matrix.
-   * @param {MatrixEntryCallback<ScalarType>} callback
+   * @param callback - The function to execute for each entry
    */
   forEachEntry(callback: MatrixEntryCallback<ScalarType>): void;
 }

--- a/src/types/matrix/MatrixBuilder.ts
+++ b/src/types/matrix/MatrixBuilder.ts
@@ -45,7 +45,7 @@ export class MatrixBuilder<
    * // [ 2 5 ]
    * // [ 3 6 ]
    * ```
-   * @param columns
+   * @param columns - The vectors to use as the columns of the new matrix
    */
   fromColumnVectors(columns: Vector<ScalarType>[]): MatrixType {
     assertHomogeneous(columns);
@@ -73,8 +73,8 @@ export class MatrixBuilder<
    * // [ 4 5 6 ]
    * ```
    *
-   * @param rows
-   * @returns {MatrixType}
+   * @param rows - The vectors to use as the rows of the new matrix
+   * @returns The new matrix
    */
   fromRowVectors(rows: Vector<ScalarType>[]): MatrixType {
     assertHomogeneous(rows);
@@ -100,10 +100,10 @@ export class MatrixBuilder<
    * // [ 4 5 6 7 ]
    * // [ 5 6 7 8 ]
    * ```
-   * @param {number} numRows
-   * @param {number} numColumns
-   * @param {MatrixIndexFunction} indexFunction  A function returning the entry for a given `i`, `j`
-   * @returns {MatrixType}
+   * @param numRows - The number of columns the new matrix should have
+   * @param numColumns - The number of columns the new matrix should have
+   * @param indexFunction - A function returning the entry for a given `i`, `j`
+   * @returns The new matrix
    */
   fromIndexFunction(
     numRows: number,
@@ -138,10 +138,10 @@ export class MatrixBuilder<
    * // [ 1 1 1 ]
    * // [ 5 5 5 ]
    * ```
-   * @param {Matrix<ScalarType>} matrix  The matrix on whose entries to base the entries of the new matrix
-   * @param {MatrixEntryFunction<ScalarType>} entryFunction  A function which takes an entry of
+   * @param matrix - The matrix on whose entries to base the entries of the new matrix
+   * @param entryFunction - A function which takes an entry of
    *     the original matrix and its indices, and returns the corresponding entry of the new matrix
-   * @returns {VectorType}
+   * @returns The new matrix
    */
   map(matrix: Matrix<ScalarType>, entryFunction: MatrixEntryFunction<ScalarType>): MatrixType {
     return this.fromIndexFunction(matrix.getNumberOfRows(), matrix.getNumberOfColumns(), (i, j) =>
@@ -171,10 +171,10 @@ export class MatrixBuilder<
    * // [ 2 2 2 2 ]
    * ```
    *
-   * @param {ScalarType} value
-   * @param {number} numberOfRows
-   * @param {number} numberOfColumns
-   * @returns {MatrixType}
+   * @param value - The value that should be used for every entry in the new matrix
+   * @param numberOfRows - The number of rows the new matrix should have
+   * @param numberOfColumns - The number of columns the new matrix should have
+   * @returns The new matrix
    */
   fill(
     value: ScalarType,
@@ -193,9 +193,9 @@ export class MatrixBuilder<
    * // [ 0 0 0 ]
    * // [ 0 0 0 ]
    * ```
-   * @param {number} numberOfRows
-   * @param {number} numberOfColumns
-   * @returns {MatrixType}
+   * @param numberOfRows - The number of rows the new matrix should have
+   * @param numberOfColumns - The number of columns the new matrix should have
+   * @returns The new matrix
    */
   zeros(numberOfRows: number, numberOfColumns: number = numberOfRows): MatrixType {
     return this.fill(this.ops().zero(), numberOfRows, numberOfColumns);
@@ -210,9 +210,9 @@ export class MatrixBuilder<
    * // [ 1 1 1 ]
    * // [ 1 1 1 ]
    * ```
-   * @param {number} numberOfRows
-   * @param {number} numberOfColumns
-   * @returns {MatrixType}
+   * @param numberOfRows - The number of rows the new matrix should have
+   * @param numberOfColumns - The number of columns the new matrix should have
+   * @returns The new matrix
    */
   ones(numberOfRows: number, numberOfColumns: number = numberOfRows): MatrixType {
     return this.fill(this.ops().one(), numberOfRows, numberOfColumns);
@@ -228,8 +228,8 @@ export class MatrixBuilder<
    * // [ 0 1 0 ]
    * // [ 0 0 1 ]
    * ```
-   * @param {number} size
-   * @returns {MatrixType}
+   * @param size - The dimension of the vector space for which the new matrix is the identity
+   * @returns The new matrix
    */
   identity(size: number): MatrixType {
     return this.fromIndexFunction(
@@ -243,10 +243,10 @@ export class MatrixBuilder<
    * Returns a matrix of the specified size whose entries are (uniformly-distributed) random
    * numbers between `min` and `max`
    *
-   * @param numberOfRows
-   * @param numberOfColumns
-   * @param min
-   * @param max
+   * @param numberOfRows - The number of rows the new matrix should have
+   * @param numberOfColumns - The number of columns the new matrix should have
+   * @param min - The lower limit of the random numbers to include
+   * @param max - The upper limit of the random numbers to include
    */
   random(
     numberOfRows: number,
@@ -264,10 +264,10 @@ export class MatrixBuilder<
    * Returns a matrix of the specified size whose entries are normally distributed with the
    * specified mean and standard deviation.
    *
-   * @param numberOfRows
-   * @param numberOfColumns
-   * @param mean
-   * @param standardDeviation
+   * @param numberOfRows - The number of rows the new matrix should have
+   * @param numberOfColumns - The number of columns the new matrix should have
+   * @param mean - The center of the distribution of random numbers to include
+   * @param standardDeviation - The standard deviation of the distribution of random numbers to include
    */
   randomNormal(
     numberOfRows: number,
@@ -294,8 +294,8 @@ export class MatrixBuilder<
    * // [ 0 2 0 ]
    * // [ 0 0 3 ]
    * ```
-   * @param {VectorType} diagonalEntries
-   * @returns {MatrixType}
+   * @param diagonalEntries - A vector whose entries will be used as the diagonal entries of the new matrix
+   * @returns The new matrix
    */
   diagonal(diagonalEntries: VectorType): MatrixType {
     const size = diagonalEntries.getDimension();
@@ -326,10 +326,10 @@ export class MatrixBuilder<
    * // [ 0 2 5 ]
    * ```
    *
-   * @param {VectorType} leftEntries
-   * @param {VectorType} diagonalEntries
-   * @param {VectorType} rightEntries
-   * @returns {MatrixType}
+   * @param leftEntries - A vector whose entries will be used in the left off-diagonal
+   * @param diagonalEntries - A vector whose entries will be used in the diagonal
+   * @param rightEntries - A vector whose entries will be used in the right off-diagonal
+   * @returns The new matrix
    */
   tridiagonal(
     leftEntries: Vector<ScalarType>,
@@ -370,9 +370,9 @@ export class MatrixBuilder<
    * // [ 1 1 1 0 0 0 0 ]
    * // [ 1 1 1 0 0 0 0 ]
    * ```
-   * @param {MatrixType} left
-   * @param {MatrixType} right
-   * @returns {MatrixType}
+   * @param left - The matrix that will form the left-side of the augmented matrix
+   * @param right - The matrix that will form the right-side of the augmented matrix
+   * @returns The new augmented matrix
    */
   augment(left: Matrix<ScalarType>, right: Matrix<ScalarType>): MatrixType {
     if (left.getNumberOfRows() !== right.getNumberOfRows()) {
@@ -396,9 +396,9 @@ export class MatrixBuilder<
    * // [ 1 1 1 ]
    * // [ 0 0 0 ]
    * ```
-   * @param {MatrixType} top
-   * @param {MatrixType} bottom
-   * @returns {MatrixType}
+   * @param top - The matrix that will be used for the top half of the new matrix
+   * @param bottom - The matrix that will be used for the bottom half of the new matrix
+   * @returns The new matrix
    */
   private stack(top: Matrix<ScalarType>, bottom: Matrix<ScalarType>): MatrixType {
     if (top.getNumberOfColumns() !== bottom.getNumberOfColumns()) {
@@ -429,8 +429,8 @@ export class MatrixBuilder<
    * // [ 0 1 1 ]
    * // [ 0 1 1 ]
    * ```
-   * @param {Array<Array<MatrixType>>} grid
-   * @returns {MatrixType}
+   * @param grid - A 2-dimensional array of matrices that will be combined into the new matrix
+   * @returns The new matrix
    */
   flatten(grid: Array<Array<MatrixType>>): MatrixType {
     if (grid.length === 0 || grid[0].length === 0) {
@@ -458,10 +458,10 @@ export class MatrixBuilder<
    * // [ 1 0 1 0 ]
    * // [ 0 1 0 1 ]
    * ```
-   * @param {MatrixType} matrix
-   * @param {number} rows
-   * @param {number} columns
-   * @returns {MatrixType}
+   * @param matrix - The matrix to be repeated
+   * @param rows - The number of times to repeat the matrix vertically
+   * @param columns - The number of times to repeat the matrix horizontally
+   * @returns The new matrix
    */
   repeat(matrix: MatrixType, rows: number, columns: number): MatrixType {
     const grid: Array<Array<MatrixType>> = [];
@@ -489,12 +489,12 @@ export class MatrixBuilder<
    * // [  0  0  0  1  ]
    * ```
    *
-   * @param {MatrixType} matrix  The original matrix
-   * @param {number} rowStartIndex  The (inclusive) first row of the slice
-   * @param {number} columnStartIndex  The (inclusive) first column of the slice
-   * @param {number} rowEndIndex  The (exclusive) last row of the slice
-   * @param {number} columnEndIndex  The (exclusive) last column of the slice
-   * @returns {MatrixType}
+   * @param matrix - The original matrix
+   * @param rowStartIndex - The (inclusive) first row of the slice
+   * @param columnStartIndex - The (inclusive) first column of the slice
+   * @param rowEndIndex - The (exclusive) last row of the slice
+   * @param columnEndIndex - The (exclusive) last column of the slice
+   * @returns The new matrix
    */
   slice(
     matrix: Matrix<ScalarType>,
@@ -543,10 +543,10 @@ export class MatrixBuilder<
    * // [  0  0  1* 0  ]      [ 0 0 0 ]
    * // [  0  0  0* 1  ]      [ 0 0 1 ]
    * ```
-   * @param {MatrixType} matrix
-   * @param {number} rowToExclude
-   * @param {number} columnToExclude
-   * @returns {MatrixType}
+   * @param matrix - The input matrix
+   * @param rowToExclude - The index of the row that will be removed
+   * @param columnToExclude - The index of the column that will be removed
+   * @returns The new matrix
    */
   exclude(matrix: MatrixType, rowToExclude: number, columnToExclude: number): MatrixType {
     assertValidMatrixIndex(matrix, rowToExclude, columnToExclude);

--- a/src/types/matrix/NumberMatrix.ts
+++ b/src/types/matrix/NumberMatrix.ts
@@ -23,14 +23,23 @@ export class NumberMatrix extends ArrayMatrix<number> {
     return new VectorBuilder(NumberVector);
   }
 
+  /**
+   * @inheritdoc
+   */
   ops() {
     return NumberMatrix.ops();
   }
 
+  /**
+   * @inheritdoc
+   */
   builder(): MatrixBuilder<number, NumberVector, NumberMatrix> {
     return NumberMatrix.builder();
   }
 
+  /**
+   * @inheritdoc
+   */
   vectorBuilder(): VectorBuilder<number, NumberVector> {
     return NumberMatrix.vectorBuilder();
   }

--- a/src/types/scalar/ScalarOperations.ts
+++ b/src/types/scalar/ScalarOperations.ts
@@ -3,7 +3,7 @@ export abstract class ScalarOperations<ScalarType> {
    * Returns true if the scalars are equal.
    * Implementors should ensure that the operation is reflexive, associative, and transitive.
    *
-   * @returns {boolean}  true if `first` is equal to `second`
+   * @returns true if `first` is equal to `second`
    */
   abstract equals(first: ScalarType, second: ScalarType): boolean;
 
@@ -11,7 +11,7 @@ export abstract class ScalarOperations<ScalarType> {
    * Returns the sum of two scalars.
    * Implementors should ensure that this operation is commutative and associative.
    *
-   * @returns {ScalarType}  The sum of `first` and `second`
+   * @returns The sum of `first` and `second`
    */
   abstract add(first: ScalarType, second: ScalarType): ScalarType;
 
@@ -24,7 +24,7 @@ export abstract class ScalarOperations<ScalarType> {
    * Implementors should ensure that this operation is commutative and associative,
    * and that it distributes over the addition operation.
    *
-   * @returns {ScalarType}  The product of `first` and `second`
+   * @returns The product of `first` and `second`
    */
   abstract multiply(first: ScalarType, second: ScalarType): ScalarType;
 
@@ -39,8 +39,8 @@ export abstract class ScalarOperations<ScalarType> {
   /**
    * Returns the complex conjugate of a scalar.
    * For real-valued scalars, this can just be an identity function.
-   * @param {ScalarType} scalar  The scalar to conjugate
-   * @returns {ScalarType}  The complex conjugate
+   * @param scalar - The scalar to conjugate
+   * @returns The complex conjugate
    */
   abstract conjugate(scalar: ScalarType): ScalarType;
 
@@ -49,7 +49,7 @@ export abstract class ScalarOperations<ScalarType> {
    * `addScalars(x, getAdditiveIdentity()) === x`
    * is true for all scalars `x`
    *
-   * @returns {ScalarType}  The additive identity
+   * @returns The additive identity
    */
   abstract getAdditiveIdentity(): ScalarType;
 
@@ -65,7 +65,7 @@ export abstract class ScalarOperations<ScalarType> {
    * `addScalars(scalar, getAdditiveInverse(scalar)) === getAdditiveIdentity()`
    * is true for `scalar`
    *
-   * @returns {ScalarType}  The additive inverse
+   * @returns The additive inverse
    */
   abstract getAdditiveInverse(x: ScalarType): ScalarType;
 
@@ -74,7 +74,7 @@ export abstract class ScalarOperations<ScalarType> {
    * `multiplyScalars(x, getMultiplicativeIdentity()) === x`
    * is true for all x
    *
-   * @returns {ScalarType}  The multiplicative identity
+   * @returns The multiplicative identity
    */
   abstract getMultiplicativeIdentity(): ScalarType;
 
@@ -101,7 +101,7 @@ export abstract class ScalarOperations<ScalarType> {
    *
    * is true for `scalar`
    *
-   * @returns {ScalarType}  The multiplicative inverse
+   * @returns The multiplicative inverse
    */
   abstract getMultiplicativeInverse(x: ScalarType): ScalarType | undefined;
 

--- a/src/types/vector/ArrayVector.ts
+++ b/src/types/vector/ArrayVector.ts
@@ -20,11 +20,17 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
   abstract builder(): VectorBuilder<ScalarType, Vector<ScalarType>>;
   abstract matrixBuilder(): MatrixBuilder<ScalarType, Vector<ScalarType>, Matrix<ScalarType>>;
 
+  /**
+   * @inheritdoc
+   */
   getEntry(index: number): ScalarType {
     assertValidVectorIndex(this, index);
     return this._data[index];
   }
 
+  /**
+   * @inheritdoc
+   */
   add(other: Vector<ScalarType>): Vector<ScalarType> {
     assertHomogeneous([this, other]);
 
@@ -35,6 +41,9 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
     return this.builder().fromData(newData);
   }
 
+  /**
+   * @inheritdoc
+   */
   equals(other: Vector<ScalarType>): boolean {
     if (this.getDimension() !== other.getDimension()) {
       return false;
@@ -45,6 +54,9 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
       .reduce((all, current) => all && current, true);
   }
 
+  /**
+   * @inheritdoc
+   */
   innerProduct(other: Vector<ScalarType>): ScalarType {
     assertHomogeneous([this, other]);
 
@@ -55,6 +67,9 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
       .reduce(this.ops().add, this.ops().zero());
   }
 
+  /**
+   * @inheritdoc
+   */
   outerProduct(other: Vector<ScalarType>): Matrix<ScalarType> {
     const matrixData: MatrixData<ScalarType> = [];
 
@@ -72,10 +87,16 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
     return this.matrixBuilder().fromData(matrixData);
   }
 
+  /**
+   * @inheritdoc
+   */
   norm(): ScalarType {
     return this.ops().getPrincipalSquareRoot(this.innerProduct(this));
   }
 
+  /**
+   * @inheritdoc
+   */
   normalize(): Vector<ScalarType> | undefined {
     const oneOverNorm = this.ops().getMultiplicativeInverse(this.norm());
     if (oneOverNorm === undefined) {
@@ -84,6 +105,9 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
     return this.scalarMultiply(oneOverNorm);
   }
 
+  /**
+   * @inheritdoc
+   */
   projectOnto(u: Vector<ScalarType>) {
     const oneOverUDotU = this.ops().getMultiplicativeInverse(u.innerProduct(u));
     if (oneOverUDotU === undefined) {
@@ -95,14 +119,23 @@ export abstract class ArrayVector<ScalarType> implements Vector<ScalarType> {
     return u.scalarMultiply(magnitudeOfProjection);
   }
 
+  /**
+   * @inheritdoc
+   */
   scalarMultiply(scalar: ScalarType): Vector<ScalarType> {
     return this.builder().fromData(this.getData().map(entry => this.ops().multiply(entry, scalar)));
   }
 
+  /**
+   * @inheritdoc
+   */
   getData(): VectorData<ScalarType> {
     return [...this._data];
   }
 
+  /**
+   * @inheritdoc
+   */
   getDimension(): number {
     return this._data.length;
   }

--- a/src/types/vector/ComplexVector.ts
+++ b/src/types/vector/ComplexVector.ts
@@ -19,14 +19,23 @@ export class ComplexVector extends ArrayVector<ComplexNumber> {
     return new VectorBuilder(ComplexVector);
   }
 
+  /**
+   * @inheritdoc
+   */
   ops(): ComplexNumberOperations {
     return ComplexVector.ops();
   }
 
+  /**
+   * @inheritdoc
+   */
   builder(): VectorBuilder<ComplexNumber, ComplexVector> {
     return ComplexVector.builder();
   }
 
+  /**
+   * @inheritdoc
+   */
   matrixBuilder() {
     return ComplexMatrix.builder();
   }

--- a/src/types/vector/NumberVector.ts
+++ b/src/types/vector/NumberVector.ts
@@ -18,14 +18,23 @@ export class NumberVector extends ArrayVector<number> {
     return new VectorBuilder(NumberVector);
   }
 
+  /**
+   * @inheritdoc
+   */
   ops(): NumberOperations {
     return NumberVector.ops();
   }
 
+  /**
+   * @inheritdoc
+   */
   builder(): VectorBuilder<number, NumberVector> {
     return NumberVector.builder();
   }
 
+  /**
+   * @inheritdoc
+   */
   matrixBuilder() {
     return NumberMatrix.builder();
   }

--- a/src/types/vector/SparseVector.ts
+++ b/src/types/vector/SparseVector.ts
@@ -42,10 +42,16 @@ export abstract class SparseVector<ScalarType> implements Vector<ScalarType> {
 
   abstract matrixBuilder(): MatrixBuilder<ScalarType, Vector<ScalarType>, Matrix<ScalarType>>;
 
+  /**
+   * @inheritdoc
+   */
   getSparseData(): SparseVectorData<ScalarType> {
     return this._sparseData;
   }
 
+  /**
+   * @inheritdoc
+   */
   getData(): VectorData<ScalarType> {
     const data: VectorData<ScalarType> = [];
     for (let i = 0; i < this.getDimension(); i++) {
@@ -54,11 +60,17 @@ export abstract class SparseVector<ScalarType> implements Vector<ScalarType> {
     return data;
   }
 
+  /**
+   * @inheritdoc
+   */
   getEntry(index: number): ScalarType {
     assertValidVectorIndex(this, index);
     return this._sparseData.get(index) || this.ops().zero();
   }
 
+  /**
+   * @inheritdoc
+   */
   innerProduct(other: Vector<ScalarType>): ScalarType {
     let innerProduct: ScalarType = this.ops().zero();
     this._sparseData.forEach((value, index) => {
@@ -70,11 +82,17 @@ export abstract class SparseVector<ScalarType> implements Vector<ScalarType> {
     return innerProduct;
   }
 
+  /**
+   * @inheritdoc
+   */
   outerProduct(other: Vector<ScalarType>): Matrix<ScalarType> {
     // TODO - implement.  This is just here to satisfy the compiler.
     return this.matrixBuilder().fromData([other.getData()]);
   }
 
+  /**
+   * @inheritdoc
+   */
   scalarMultiply(scalar: ScalarType): Vector<ScalarType> {
     const newSparseData = new Map();
     this._sparseData.forEach((value, index) => {
@@ -85,6 +103,9 @@ export abstract class SparseVector<ScalarType> implements Vector<ScalarType> {
 
   abstract add(other: Vector<ScalarType>): Vector<ScalarType>;
 
+  /**
+   * @inheritdoc
+   */
   equals(other: Vector<ScalarType>): boolean {
     if (isSparse(other)) {
       return this.equalsSparse(other);
@@ -111,14 +132,23 @@ export abstract class SparseVector<ScalarType> implements Vector<ScalarType> {
     return hasMismatch;
   }
 
+  /**
+   * @inheritdoc
+   */
   getDimension(): number {
     return this._dimension;
   }
 
+  /**
+   * @inheritdoc
+   */
   norm(): ScalarType {
     return this.ops().getPrincipalSquareRoot(this.innerProduct(this));
   }
 
+  /**
+   * @inheritdoc
+   */
   normalize(): Vector<ScalarType> | undefined {
     const oneOverNorm = this.ops().getMultiplicativeInverse(this.norm());
     if (oneOverNorm === undefined) {
@@ -127,6 +157,9 @@ export abstract class SparseVector<ScalarType> implements Vector<ScalarType> {
     return this.scalarMultiply(oneOverNorm);
   }
 
+  /**
+   * @inheritdoc
+   */
   projectOnto(u: Vector<ScalarType>) {
     const oneOverUDotU = this.ops().getMultiplicativeInverse(u.innerProduct(u));
     if (oneOverUDotU === undefined) {

--- a/src/types/vector/Vector.ts
+++ b/src/types/vector/Vector.ts
@@ -15,74 +15,86 @@ export interface VectorConstructor<ScalarType, VectorType extends Vector<ScalarT
  * An interface for a member of a vector space - specifically a member of an inner product space.
  */
 export interface Vector<ScalarType> {
+  /**
+   * Yields a `ScalarOperations` object which will allow consumers to work generically
+   * with the scalars contained in the vector.
+   */
   ops(): ScalarOperations<ScalarType>;
+
+  /**
+   * Yields a `VectorBuilder` which will build new vectors of the same type
+   */
   builder(): VectorBuilder<ScalarType, Vector<ScalarType>>;
+
+  /**
+   * Yields a `MatrixBuilder` which will build new matrices of a compatible type
+   */
   matrixBuilder(): MatrixBuilder<ScalarType, Vector<ScalarType>, Matrix<ScalarType>>;
 
   /**
-   * @returns {VectorData<ScalarType>}  The contents of the vector as an array
+   * @returns The contents of the vector as an array
    */
   getData(): VectorData<ScalarType>;
 
   /**
-   * @param {number} index
-   * @returns {ScalarType}  The entry located at `index`
+   * @param index - The index of the entry to retrieve
+   * @returns The entry located at `index`
    */
   getEntry(index: number): ScalarType;
 
   /**
    * Implements vector addition
    *
-   * @param {Vector<ScalarType>} other  The vector to add
-   * @returns {Vector<ScalarType>}  The vector sum
+   * @param other - The vector to add
+   * @returns The vector sum
    */
   add(other: Vector<ScalarType>): Vector<ScalarType>;
 
   /**
    * Implements vector multiplication by a scalar
    *
-   * @param {ScalarType} scalar  The scalar by which to multiply
-   * @returns {Vector<ScalarType>}  The product
+   * @param scalar - The scalar by which to multiply
+   * @returns The product
    */
   scalarMultiply(scalar: ScalarType): Vector<ScalarType>;
 
   /**
-   * @param {Vector<ScalarType>} other
-   * @returns {ScalarType}  The inner product
+   * @param other - The vector with which to calculate an inner product
+   * @returns The inner product
    */
   innerProduct(other: Vector<ScalarType>): ScalarType;
 
   /**
-   * @returns {ScalarType} the Euclidean norm of the vector
+   * @returns The Euclidean norm of the vector
    */
   norm(): ScalarType;
 
   /**
-   * @returns {Vector<ScalarType>} a new vector with the same direction
+   * @returns A new vector with the same direction
    *     but magnitude 1, or `undefined` if it is the zero vector
    */
   normalize(): Vector<ScalarType> | undefined;
 
   /**
-   * @param u - the vector on which to project this
-   * @returns this vector projected onto `u`
+   * @param u - The vector on which to project this
+   * @returns This vector projected onto `u`
    */
   projectOnto(u: Vector<ScalarType>): Vector<ScalarType>;
 
   /**
-   * @param {Vector<ScalarType>} other
-   * @returns {Matrix<ScalarType>}  The outer product
+   * @param other - The vector with which to calculate an outer product
+   * @returns The outer product
    */
   outerProduct(other: Vector<ScalarType>): Matrix<ScalarType>;
 
   /**
-   * @returns {number}  The dimension of the vector
+   * @returns The dimension of the vector
    */
   getDimension(): number;
 
   /**
-   * @param {Vector<ScalarType>} other
-   * @returns {boolean}  true if `this` is equal to `other`
+   * @param other - The vector against which to compare
+   * @returns - `true` if `this` is equal to `other`
    */
   equals(other: Vector<ScalarType>): boolean;
 }

--- a/src/types/vector/VectorBuilder.ts
+++ b/src/types/vector/VectorBuilder.ts
@@ -43,9 +43,9 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * ```
    * vectorBuilder.fromIndexFunction(4, i => i + 3); // [ 3 4 5 6 ]
    * ```
-   * @param {number} dimension  The dimension of the vector to generate
-   * @param {VectorIndexFunction} valueFromIndex  A function returning the entry for a given index
-   * @returns {VectorType}
+   * @param dimension - The dimension of the vector to generate
+   * @param valueFromIndex - A function returning the entry for a given index
+   * @returns The new vector
    */
   fromIndexFunction(
     dimension: number,
@@ -71,10 +71,10 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * const originalPlusIndex = vectorBuilder.map(original, (value, index) => value + index);
    * // [1, 3, 5, 7]
    * ```
-   * @param {VectorType} vector  The vector on whose entries to base the entries of the new vector
-   * @param {VectorEntryFunction<ScalarType>} valueFromEntry  A function which takes an entry of
+   * @param vector - The vector on whose entries to base the entries of the new vector
+   * @param valueFromEntry - A function which takes an entry of
    *     the original vector and its index, and returns the corresponding entry of the new vector
-   * @returns {VectorType}
+   * @returns The new vector
    */
   map(vector: Vector<ScalarType>, valueFromEntry: VectorEntryFunction<ScalarType>): VectorType {
     return this.fromData(vector.getData().map(valueFromEntry));
@@ -87,7 +87,7 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * vectorBuilder.empty(); // []
    * ```
    *
-   * @returns {VectorType}
+   * @returns The new vector
    */
   empty(): VectorType {
     return this.fromData([]);
@@ -100,9 +100,9 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * vectorBuilder.fill(3, 5); // [ 3 3 3 3 3 ]
    * ```
    *
-   * @param value
-   * @param dimension
-   * @returns {VectorType}
+   * @param value - The value to use as the entries of the new vector
+   * @param dimension - The dimension of the new vector
+   * @returns The new vector
    */
   fill(value: ScalarType, dimension: number): VectorType {
     assertValidDimension(dimension);
@@ -115,8 +115,8 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * ```
    * vectorBuilder.zeros(3); // [ 0 0 0 ]
    * ```
-   * @param {number} dimension  The dimension of the vector to construct
-   * @returns {VectorType}
+   * @param dimension - The dimension of the vector to construct
+   * @returns The new vector
    */
   zeros(dimension: number): VectorType {
     return this.fill(this.ops().zero(), dimension);
@@ -128,8 +128,8 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * ```
    * vectorBuilder.ones(3); // [ 1 1 1 ]
    * ```
-   * @param {number} dimension
-   * @returns {VectorType}
+   * @param dimension - The dimension of the new vector
+   * @returns The new vector
    */
   ones(dimension: number): VectorType {
     return this.fill(this.ops().one(), dimension);
@@ -142,9 +142,9 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * vectorBuilder.elementaryVector(4, 2); // [ 0 0 1 0 ]
    * vectorBuilder.elementaryVector(3, 0); // [ 1 0 0 ]
    * ```
-   * @param {number} dimension
-   * @param {number} oneIndex
-   * @returns {VectorType}
+   * @param dimension - The dimension of the new vector
+   * @param oneIndex - The index of the element that should be the multiplicative identity
+   * @returns The new vector
    */
   elementaryVector(dimension: number, oneIndex: number): VectorType {
     assertValidDimension(dimension);
@@ -159,9 +159,9 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * Builds a vector whose entries are (uniformly-distributed) random numbers
    * between `min` and `max`
    *
-   * @param dimension
-   * @param min
-   * @param max
+   * @param dimension - The dimension of the new vector
+   * @param min - The lower limit of the random numbers to include
+   * @param max - The upper limit of the random numbers to include
    */
   random(dimension: number, min: number = 0, max: number = 1): VectorType {
     if (min >= max) {
@@ -174,9 +174,9 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    * Builds a vector whose entries are normally distributed, with the specified
    * mean and standard deviation
    *
-   * @param dimension
-   * @param mean
-   * @param standardDeviation
+   * @param dimension - The dimension of the new vector
+   * @param mean - The center of the distribution of random numbers to include
+   * @param standardDeviation - The standard deviation of the distribution of random numbers to include
    */
   randomNormal(dimension: number, mean: number = 0, standardDeviation: number = 1): VectorType {
     if (standardDeviation <= 0) {
@@ -196,9 +196,9 @@ export class VectorBuilder<ScalarType, VectorType extends Vector<ScalarType>> {
    *
    * vectorBuilder.concatenate(first, second); // [ 1 1 1 0 0 ]
    * ```
-   * @param {VectorType} first
-   * @param {VectorType} second
-   * @returns {VectorType}
+   * @param first - The vector which will be used for the entries starting with index 0
+   * @param second - The vector which will be used for the entries starting with `first.getDimension()`
+   * @returns The new vector
    */
   concatenate(first: VectorType, second: VectorType): VectorType {
     return this.fromData([...first.getData(), ...second.getData()]);

--- a/src/utilities/MatrixProperties.ts
+++ b/src/utilities/MatrixProperties.ts
@@ -1,8 +1,8 @@
 import { Matrix } from '../types/matrix/Matrix';
 
 /**
- * @param {Matrix<any>} matrix
- * @returns {boolean} true if `matrix` is square
+ * @param matrix - The matrix to check
+ * @returns `true` if `matrix` is square
  */
 export function isSquare(matrix: Matrix<any>): boolean {
   return matrix.getNumberOfColumns() === matrix.getNumberOfRows();


### PR DESCRIPTION
- Remove type annotations in @param and @returns tags
- Use @inheritdoc where needed